### PR TITLE
[MMCA-4288] - Update version, configuration & warnings for CDS Financials service - Oct'23 - V2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 import scoverage.ScoverageKeys
 import uk.gov.hmrc.DefaultBuildSettings.{integrationTestSettings, targetJvm}
-import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin.publishingSettings
 
 val appName = "customs-duty-deferment-frontend"
 
@@ -30,7 +29,6 @@ lazy val microservice = Project(appName, file("."))
     )
     // ***************
   )
-  .settings(publishingSettings: _*)
   .configs(IntegrationTest)
-  .settings(integrationTestSettings(): _*)
+  .settings(integrationTestSettings() *)
   .settings(resolvers += Resolver.jcenterRepo)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,19 +1,19 @@
-import sbt._
+import sbt.*
 
 object AppDependencies {
 
-  val bootstrapVersion = "7.22.0"
+  private val bootstrapVersion = "7.22.0"
 
-  val compile = Seq(
+  val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % bootstrapVersion,
-    "uk.gov.hmrc" %% "play-frontend-hmrc" % "7.19.0-play-28",
+    "uk.gov.hmrc" %% "play-frontend-hmrc" % "7.23.0-play-28",
     "uk.gov.hmrc" %% "play-conditional-form-mapping" % "1.13.0-play-28",
     "org.typelevel" %% "cats-core" % "2.9.0",
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28" % "1.3.0",
     "uk.gov.hmrc" %% "emailaddress" % "3.8.0"
   )
 
-  val test = Seq(
+  val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc" %% "bootstrap-test-play-28" % bootstrapVersion % Test,
     "org.jsoup" % "jsoup" % "1.16.1" % Test,
     "com.vladsch.flexmark" % "flexmark-all" % "0.36.8" % "test, it",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,11 +2,10 @@ resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefac
 resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.12.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.14.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.20")
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
 addSbtPlugin("uk.gov.hmrc" % "sbt-play-cross-compilation" % "2.3.0")
 addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "1.5.2")
-


### PR DESCRIPTION
Description - Library updates and update to remove warnings

Below has been done as part of this PR

- Update uk.gov.hmrc: play-frontend-hmrc to 7.23.0-play-28
- Very minor refactoring
- Update to remove warnings for deprecated stuff 