### PR TITLE
[MMCA-5140] - Replace old data store endpoints to new ones

### DIFF
--- a/app/connectors/DataStoreConnector.scala
+++ b/app/connectors/DataStoreConnector.scala
@@ -35,7 +35,7 @@ class DataStoreConnector @Inject() (httpClient: HttpClientV2, appConfig: AppConf
 ) {
 
   def getAllEoriHistory(eori: String)(implicit hc: HeaderCarrier): Future[Seq[EoriHistory]] = {
-    val eoriHistoryEndPoint = s"${appConfig.customsDataStore}/eori/$eori/eori-history"
+    val eoriHistoryEndPoint = s"${appConfig.customsDataStore}/eori/eori-history"
 
     httpClient
       .get(url"$eoriHistoryEndPoint")
@@ -46,8 +46,8 @@ class DataStoreConnector @Inject() (httpClient: HttpClientV2, appConfig: AppConf
       .recover { case _ => Seq(EoriHistory(eori, None, None)) }
   }
 
-  def getEmail(eori: String)(implicit hc: HeaderCarrier): Future[Either[EmailResponses, Email]] = {
-    val dataStoreEndpoint = s"${appConfig.customsDataStore}/eori/$eori/verified-email"
+  def getEmail(implicit hc: HeaderCarrier): Future[Either[EmailResponses, Email]] = {
+    val dataStoreEndpoint = s"${appConfig.customsDataStore}/eori/verified-email"
 
     httpClient
       .get(url"$dataStoreEndpoint")

--- a/app/controllers/DirectDebitController.scala
+++ b/app/controllers/DirectDebitController.scala
@@ -49,8 +49,7 @@ class DirectDebitController @Inject() (
                                Redirect(appConfig.financialsHomepage)
                              )
       email               <- fromOptionF(
-                               dateStoreConnector
-                                 .getEmail(req.request.user.eori)
+                               dateStoreConnector.getEmail
                                  .map {
                                    case Right(email) => Some(email)
                                    case Left(_)      => None

--- a/app/controllers/actions/EmailAction.scala
+++ b/app/controllers/actions/EmailAction.scala
@@ -36,8 +36,7 @@ class EmailAction @Inject() (dataStoreConnector: DataStoreConnector)(implicit
   def filter[A](request: AuthenticatedRequest[A]): Future[Option[Result]] = {
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
 
-    dataStoreConnector
-      .getEmail(request.user.eori)
+    dataStoreConnector.getEmail
       .map {
         case Left(value) => redirectBasedOnEmailResponse(value)
         case Right(_)    => None

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,6 @@ import scoverage.ScoverageKeys
 
 val appName         = "customs-duty-deferment-frontend"
 val testDirectory   = "test"
-val bootstrap       = "9.0.0"
 val scala3_3_4      = "3.3.4"
 val silencerVersion = "1.7.14"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,18 @@
 import scoverage.ScoverageKeys
 
-val appName = "customs-duty-deferment-frontend"
-val testDirectory = "test"
-val bootstrap = "9.0.0"
-val scala3_3_3 = "3.3.3"
+val appName         = "customs-duty-deferment-frontend"
+val testDirectory   = "test"
+val bootstrap       = "9.0.0"
+val scala3_3_4      = "3.3.4"
 val silencerVersion = "1.7.14"
 
 ThisBuild / majorVersion := 0
-ThisBuild / scalaVersion := scala3_3_3
+ThisBuild / scalaVersion := scala3_3_4
 
 lazy val scalastyleSettings = Seq(
   scalastyleConfig := baseDirectory.value / "scalastyle-config.xml",
-  (Test / scalastyleConfig) := baseDirectory.value / testDirectory / "test-scalastyle-config.xml")
+  (Test / scalastyleConfig) := baseDirectory.value / testDirectory / "test-scalastyle-config.xml"
+)
 
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
@@ -20,15 +21,16 @@ lazy val microservice = Project(appName, file("."))
     PlayKeys.playDefaultPort := 9397,
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
     scalacOptions := scalacOptions.value.diff(Seq("-Wunused:all")),
+    scalacOptions += "-Wconf:msg=Flag.*repeatedly:s",
     Test / scalacOptions ++= Seq(
       "-Wunused:imports",
       "-Wunused:params",
       "-Wunused:implicits",
       "-Wunused:explicits",
-      "-Wunused:privates"),
-
-    ScoverageKeys.coverageExcludedFiles := List(
-      "<empty>", "Reverse.*", ".*(BuildInfo|Routes|testOnly).*", ".*views.*").mkString(";"),
+      "-Wunused:privates"
+    ),
+    ScoverageKeys.coverageExcludedFiles := List("<empty>", "Reverse.*", ".*(BuildInfo|Routes|testOnly).*", ".*views.*")
+      .mkString(";"),
     ScoverageKeys.coverageMinimumStmtTotal := 90,
     ScoverageKeys.coverageMinimumBranchTotal := 90,
     ScoverageKeys.coverageFailOnMinimum := false,
@@ -36,8 +38,9 @@ lazy val microservice = Project(appName, file("."))
     Assets / pipelineStages := Seq(gzip),
     libraryDependencies ++= Seq(
       compilerPlugin(
-        "com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.for3Use2_13With("", ".12")),
-      "com.github.ghik" % "silencer-lib" % silencerVersion % Provided cross CrossVersion.for3Use2_13With("",".12")
+        "com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.for3Use2_13With("", ".12")
+      ),
+      "com.github.ghik" % "silencer-lib" % silencerVersion % Provided cross CrossVersion.for3Use2_13With("", ".12")
     )
   )
   .settings(resolvers += Resolver.jcenterRepo)
@@ -51,7 +54,9 @@ lazy val microservice = Project(appName, file("."))
 lazy val it = project
   .enablePlugins(PlayScala)
   .dependsOn(microservice % "test->test")
-  .settings(libraryDependencies ++= Seq("uk.gov.hmrc" %% "bootstrap-test-play-30" % bootstrap % Test))
+  .settings(
+    libraryDependencies ++= Seq("uk.gov.hmrc" %% "bootstrap-test-play-30" % AppDependencies.bootstrapVersion % Test)
+  )
 
 addCommandAlias(
   "runAllChecks",

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,22 +2,22 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapVersion = "9.0.0"
+  val bootstrapVersion         = "9.0.0"
   private val hmrcMongoVersion = "2.1.0"
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc" %% "bootstrap-frontend-play-30" % bootstrapVersion,
-    "uk.gov.hmrc" %% "play-conditional-form-mapping-play-30" % "3.0.0",
-    "uk.gov.hmrc" %% "play-frontend-hmrc-play-30" % "10.3.0",
-    "org.typelevel" %% "cats-core" % "2.10.0",
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30" % hmrcMongoVersion,
+    "uk.gov.hmrc"       %% "bootstrap-frontend-play-30"            % bootstrapVersion,
+    "uk.gov.hmrc"       %% "play-conditional-form-mapping-play-30" % "3.0.0",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"            % "10.3.0",
+    "org.typelevel"     %% "cats-core"                             % "2.10.0",
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"                    % hmrcMongoVersion
   )
 
   val test: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc" %% "bootstrap-test-play-30" % bootstrapVersion % Test,
-    "org.jsoup" % "jsoup" % "1.17.2",
-    "org.scalatestplus" %% "mockito-4-11" %"3.2.18.0" % Test,
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30" % hmrcMongoVersion
+    "uk.gov.hmrc"       %% "bootstrap-test-play-30" % bootstrapVersion % Test,
+    "org.jsoup"          % "jsoup"                  % "1.17.2",
+    "org.scalatestplus" %% "mockito-4-11"           % "3.2.18.0"       % Test,
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"     % hmrcMongoVersion
   )
 }

--- a/test/connectors/DataStoreConnectorSpec.scala
+++ b/test/connectors/DataStoreConnectorSpec.scala
@@ -117,6 +117,19 @@ class DataStoreConnectorSpec extends SpecBase {
     }
   }
 
+  "verifiedEmail" should {
+    "return undelivered email" in new Setup {
+      when(requestBuilder.execute(any[HttpReads[EmailVerifiedResponse]], any[ExecutionContext]))
+        .thenReturn(Future.successful(emailVerifiedRes))
+
+      when(mockHttpClient.get(any[URL]())(any())).thenReturn(requestBuilder)
+
+      running(application) {
+        connector.verifiedEmail.map(_.verifiedEmail mustBe Some(emailVerifiedRes))
+      }
+    }
+  }
+
   "retrieveUnverifiedEmail" should {
     "return unverified email" in new Setup {
       when(requestBuilder.execute(any[HttpReads[EmailUnverifiedResponse]], any[ExecutionContext]))
@@ -127,19 +140,6 @@ class DataStoreConnectorSpec extends SpecBase {
       running(application) {
         val result = await(connector.retrieveUnverifiedEmail(hc))
         result mustBe expectedResult
-      }
-    }
-  }
-
-  "verifiedEmail" should {
-    "return undelivered email" in new Setup {
-      when(requestBuilder.execute(any[HttpReads[EmailVerifiedResponse]], any[ExecutionContext]))
-        .thenReturn(Future.successful(emailVerifiedRes))
-
-      when(mockHttpClient.get(any[URL]())(any())).thenReturn(requestBuilder)
-
-      running(application) {
-        connector.verifiedEmail.map(_.verifiedEmail mustBe Some(emailVerifiedRes))
       }
     }
   }

--- a/test/connectors/DataStoreConnectorSpec.scala
+++ b/test/connectors/DataStoreConnectorSpec.scala
@@ -71,7 +71,7 @@ class DataStoreConnectorSpec extends SpecBase {
         .thenReturn(Future.successful(emailResponse))
 
       running(application) {
-        val result = await(connector.getEmail("someEori"))
+        val result = await(connector.getEmail)
         result mustBe Right(Email("some@email.com"))
       }
     }
@@ -85,7 +85,7 @@ class DataStoreConnectorSpec extends SpecBase {
         .thenReturn(Future.successful(emailResponse))
 
       running(application) {
-        val result = await(connector.getEmail("someEori"))
+        val result = await(connector.getEmail)
         result mustBe Left(UndeliverableEmail("some@email.com"))
       }
     }
@@ -99,7 +99,7 @@ class DataStoreConnectorSpec extends SpecBase {
         .thenReturn(Future.successful(emailResponse))
 
       running(application) {
-        val result = await(connector.getEmail("someEori"))
+        val result = await(connector.getEmail)
         result mustBe Left(UnverifiedEmail)
       }
     }
@@ -111,7 +111,7 @@ class DataStoreConnectorSpec extends SpecBase {
         .thenReturn(Future.failed(UpstreamErrorResponse("Not Found", NOT_FOUND, NOT_FOUND)))
 
       running(application) {
-        val result = await(connector.getEmail("someEori"))
+        val result = await(connector.getEmail)
         result mustBe Left(UnverifiedEmail)
       }
     }

--- a/test/controllers/DirectDebitControllerSpec.scala
+++ b/test/controllers/DirectDebitControllerSpec.scala
@@ -49,7 +49,7 @@ class DirectDebitControllerSpec extends SpecBase {
       when(mockSessionCacheConnector.retrieveSession(any, any)(any))
         .thenReturn(Future.successful(Some(accountLink)))
 
-      when(mockDataStoreConnector.getEmail(any)(any))
+      when(mockDataStoreConnector.getEmail(any))
         .thenReturn(Future.successful(Left(UnverifiedEmail)))
 
       running(app) {
@@ -65,7 +65,7 @@ class DirectDebitControllerSpec extends SpecBase {
       when(mockSessionCacheConnector.retrieveSession(any, any)(any))
         .thenReturn(Future.successful(Some(accountLink)))
 
-      when(mockDataStoreConnector.getEmail(any)(any))
+      when(mockDataStoreConnector.getEmail(any))
         .thenReturn(Future.failed(new RuntimeException("Unknown error")))
 
       running(app) {
@@ -81,7 +81,7 @@ class DirectDebitControllerSpec extends SpecBase {
       when(mockSessionCacheConnector.retrieveSession(any, any)(any))
         .thenReturn(Future.successful(Some(accountLink)))
 
-      when(mockDataStoreConnector.getEmail(any)(any))
+      when(mockDataStoreConnector.getEmail(any))
         .thenReturn(Future.successful(Right(Email("some@email.com"))))
 
       when(mockSDDSConnector.startJourney(any, any)(any))
@@ -100,7 +100,7 @@ class DirectDebitControllerSpec extends SpecBase {
       when(mockSessionCacheConnector.retrieveSession(any, any)(any))
         .thenReturn(Future.successful(Some(accountLink)))
 
-      when(mockDataStoreConnector.getEmail(any)(any))
+      when(mockDataStoreConnector.getEmail(any))
         .thenReturn(Future.successful(Right(Email("some@email.com"))))
 
       when(mockSDDSConnector.startJourney(any, any)(any))

--- a/test/controllers/EmailControllerSpec.scala
+++ b/test/controllers/EmailControllerSpec.scala
@@ -18,7 +18,6 @@ package controllers
 
 import connectors.DataStoreConnector
 import models.{EmailUnverifiedResponse, EmailVerifiedResponse}
-import play.api.http.Status.OK
 import play.api.{Application, inject}
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.HttpReads

--- a/test/controllers/ShowContactDetailsControllerSpec.scala
+++ b/test/controllers/ShowContactDetailsControllerSpec.scala
@@ -81,7 +81,7 @@ class ShowContactDetailsControllerSpec extends SpecBase {
 
   "startSession" must {
     "redirect to session expired when no account link found" in new Setup {
-      when(mockDataStoreConnector.getEmail(any)(any))
+      when(mockDataStoreConnector.getEmail(any))
         .thenReturn(Future.successful(Right(Email("test@test.com"))))
       when(mockAccountLinkCacheService.cacheAccountLink(any, any, any)(any))
         .thenReturn(Future.successful(Left(NoAccountStatusId)))
@@ -94,7 +94,7 @@ class ShowContactDetailsControllerSpec extends SpecBase {
     }
 
     "redirect to 'show' when a verified email response and account link are returned" in new Setup {
-      when(mockDataStoreConnector.getEmail(any)(any))
+      when(mockDataStoreConnector.getEmail(any))
         .thenReturn(Future.successful(Right(Email("test@test.com"))))
       when(mockAccountLinkCacheService.cacheAccountLink(any, any, any)(any))
         .thenReturn(Future.successful(Right(dutyDefermentAccountLink)))
@@ -107,7 +107,7 @@ class ShowContactDetailsControllerSpec extends SpecBase {
     }
 
     "redirect to 'verify your email' page when an unverified email response is received" in new Setup {
-      when(mockDataStoreConnector.getEmail(any)(any))
+      when(mockDataStoreConnector.getEmail(any))
         .thenReturn(Future.successful(Left(UnverifiedEmail)))
 
       running(application) {
@@ -118,7 +118,7 @@ class ShowContactDetailsControllerSpec extends SpecBase {
     }
 
     "redirect to 'Undelivered email' page when an undelivered email response is received" in new Setup {
-      when(mockDataStoreConnector.getEmail(any)(any))
+      when(mockDataStoreConnector.getEmail(any))
         .thenReturn(Future.successful(Left(UndeliverableEmail("test@test.com"))))
 
       running(application) {
@@ -129,7 +129,7 @@ class ShowContactDetailsControllerSpec extends SpecBase {
     }
 
     "redirect to 'show contact details' page when an error occurs while retrieving the email" in new Setup {
-      when(mockDataStoreConnector.getEmail(any)(any))
+      when(mockDataStoreConnector.getEmail(any))
         .thenReturn(Future.failed(new RuntimeException("Error occurred")))
       when(mockAccountLinkCacheService.cacheAccountLink(any, any, any)(any))
         .thenReturn(Future.successful(Right(dutyDefermentAccountLink)))

--- a/test/controllers/actions/EmailActionSpec.scala
+++ b/test/controllers/actions/EmailActionSpec.scala
@@ -36,7 +36,7 @@ class EmailActionSpec extends SpecBase {
   "EmailAction" should {
     "Let requests with validated email through" in new Setup {
       running(application) {
-        when(mockDataStoreConnector.getEmail(any)(any))
+        when(mockDataStoreConnector.getEmail(any))
           .thenReturn(Future.successful(Right(Email("last.man@standing.co.uk"))))
 
         val response = await(emailAction.filter(authenticatedRequest))
@@ -46,7 +46,7 @@ class EmailActionSpec extends SpecBase {
 
     "Let request through, when getEmail throws service unavailable exception" in new Setup {
       running(application) {
-        when(mockDataStoreConnector.getEmail(any)(any)).thenReturn(Future.failed(new ServiceUnavailableException("")))
+        when(mockDataStoreConnector.getEmail(any)).thenReturn(Future.failed(new ServiceUnavailableException("")))
 
         val response = await(emailAction.filter(authenticatedRequest))
         response mustBe None
@@ -55,7 +55,7 @@ class EmailActionSpec extends SpecBase {
 
     "Redirect users with unvalidated emails" in new Setup {
       running(application) {
-        when(mockDataStoreConnector.getEmail(any)(any)).thenReturn(Future.successful(Left(UnverifiedEmail)))
+        when(mockDataStoreConnector.getEmail(any)).thenReturn(Future.successful(Left(UnverifiedEmail)))
 
         val response = await(emailAction.filter(authenticatedRequest))
         response.get.header.status mustBe SEE_OTHER
@@ -65,7 +65,7 @@ class EmailActionSpec extends SpecBase {
 
     "Redirect users to undelivered email page when undeliverable email response is returned" in new Setup {
       running(application) {
-        when(mockDataStoreConnector.getEmail(any)(any))
+        when(mockDataStoreConnector.getEmail(any))
           .thenReturn(Future.successful(Left(UndeliverableEmail("test@test.com"))))
 
         val response = emailAction.filter(authenticatedRequest).map(a => a.get)

--- a/test/util/TestData.scala
+++ b/test/util/TestData.scala
@@ -16,7 +16,6 @@
 
 package util
 
-import models.DDStatementType
 import models.FileRole.DutyDefermentStatement
 import models.responses.retrieve.{ContactDetails, ResponseCommon}
 import models.*


### PR DESCRIPTION
Description - Changes to replace below endpoints to the new ones

/eori/:eori/eori-history
/eori/:eori/verified-email

Below has been done as part of this PR

- [x] replace old endpoints to new ones
- [x] update tests
- [x] minor refactoring
- [x] update scala version to 3.3.4 and update build scalaoptions to fix repeatedly warnings
- [x] scala formatting for the relevant files
- [x] fixed few warnings