### PR TITLE
MMCA-5362: Create link to feedback form from confirmation pages

### DIFF
--- a/app/views/contact_details/edit_success_address.scala.html
+++ b/app/views/contact_details/edit_success_address.scala.html
@@ -46,6 +46,7 @@
             accountNo = Some(dan),
             divClass = Some("govuk-!-margin-bottom-6"))
     }
+address
 
     @cancel_button(
         href = Some(routes.ShowContactDetailsController.show().url),

--- a/app/views/contact_details/edit_success_contact.scala.html
+++ b/app/views/contact_details/edit_success_contact.scala.html
@@ -16,11 +16,16 @@
 
 @import config.AppConfig
 @import views.html.components.confirmation_panel
+@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcNewTabLinkHelper
+@import uk.gov.hmrc.hmrcfrontend.views.viewmodels.newtablinkhelper.NewTabLinkHelper
 
 @this(
         layout: Layout,
         cancel_button: components.cancel_button,
-        inputText: components.input_text
+        inputText: components.input_text,
+        p: components.p,
+        h2: components.h2,
+        hmrcNewTabLinkHelper: HmrcNewTabLinkHelper
 )
 
 @(dan: String, isNi: Boolean = false)(
@@ -51,4 +56,16 @@
         href = Some(routes.ShowContactDetailsController.show().url),
         message = messages("accountDetails.edit.confirm.back")
     )
+
+    @h2(
+        msg = messages("user-research.subheader-text"),
+        id=Some("improve-the-service-subheader-text")
+    )
+
+    @p(Html(messages("user-research.help.body-text")))
+    
+    @hmrcNewTabLinkHelper(NewTabLinkHelper(
+        text = messages("user-research.help.link"),
+        href = Some(appConfig.helpMakeGovUkBetterUrl),
+    ))
 }

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -35,6 +35,13 @@ cf.account.detail.accordion.hide-section=Cuddio
 cf.account.detail.accordion.hide-all-sections=Cuddio bob adran
 # ----------------------------------------------------------
 
+# User Research
+# ----------------------------------------------------------
+user-research.subheader-text=Helpu ni i wella’r gwasanaeth hwn
+user-research.body-text=A oes gennych rif EORI yn yr UE? Rydym yn cynnal ymchwil defnyddwyr i helpu i wella ein gwasanaethau.
+user-research.link=Cofrestrwch i gymryd rhan mewn ymchwil defnyddwyr (yn agor tab newydd)
+# ----------------------------------------------------------
+
 # Timeout Messages
 # ----------------------------------------------------------
 timeout.title=Rydych ar fin cael eich allgofnodi

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -40,6 +40,12 @@ feedback.link = feedback
 feedback.after = will help us to improve it.
 # ----------------------------------------------------------
 
+# User Research
+# ----------------------------------------------------------
+user-research.subheader-text=Help us improve the service
+user-research.help.body-text=Do you have an EU EORI number? We''re carrying out user research to help improve our services.
+user-research.help.link=Sign up to take part in user research
+
 # Timeout Messages
 # ----------------------------------------------------------
 timeout.title = You’re about to be signed out


### PR DESCRIPTION
We would like to use the content on ‘confirmation pages’ as an opportunity to prompt users who have an EU EORI to sign up to take part in user research.

This PR implaments a pathway to optimise the revruitment of new users