### PR TITLE
MMCA-5416: handle optional backLink more idiomatically and update tests in order to remove back link from pages where not requred

### DIFF
--- a/app/views/Layout.scala.html
+++ b/app/views/Layout.scala.html
@@ -88,7 +88,7 @@
                             signOutUrl = Some(routes.LogoutController.logout.url),
                             accessibilityStatementUrl = Some("/accessibility-statement/customs-financials")
                     ),
-        backLink = Some(BackLink(href = backLink.getOrElse(emptyString))),
+        backLink = backLink.map(href => BackLink(href = href)),
         templateOverrides = TemplateOverrides(
                                 additionalHeadBlock = Some(additionalHead)
                             ),

--- a/test/views/LayoutSpec.scala
+++ b/test/views/LayoutSpec.scala
@@ -77,20 +77,19 @@ class LayoutSpec extends SpecBase {
     viewDoc.html().contains("/accessibility-statement/customs-financials") mustBe true
   }
 
-  private def shouldContainCorrectBackLink(viewDoc: Document, backLinkUrl: Option[String] = None) =
-    if (backLinkUrl.isDefined) {
-      viewDoc.getElementsByClass("govuk-back-link").text() mustBe "Back"
-      viewDoc
-        .getElementsByClass("govuk-back-link")
-        .attr("href")
-        .contains(backLinkUrl.get) mustBe true
-    } else {
-      viewDoc.getElementsByClass("govuk-back-link").text() mustBe "Back"
-      viewDoc
-        .getElementsByClass("govuk-back-link")
-        .attr("href")
-        .contains("#") mustBe true
+  private def shouldContainCorrectBackLink(viewDoc: Document, backLinkUrl: Option[String] = None) = {
+    val backLinkElements = viewDoc.getElementsByClass("govuk-back-link")
+
+    backLinkUrl match {
+      case Some(url) =>
+        backLinkElements.size()       must be > 0
+        backLinkElements.text() mustBe "Back"
+        backLinkElements.attr("href") must include(url)
+
+      case None =>
+        backLinkElements.size() mustBe 0 // Expect no backlink element
     }
+  }
 
   private def shouldContainCorrectBanners(viewDoc: Document) = {
     viewDoc

--- a/test/views/LayoutSpec.scala
+++ b/test/views/LayoutSpec.scala
@@ -87,7 +87,7 @@ class LayoutSpec extends SpecBase {
         backLinkElements.attr("href") must include(url)
 
       case None =>
-        backLinkElements.size() mustBe 0 // Expect no backlink element
+        backLinkElements.size() mustBe 0
     }
   }
 


### PR DESCRIPTION
this pr is to remove the back link in the confirmation pages

I replaced non-idiomatic getOrElse + Some(...) logic with Option.map to construct BackLink only when a URL is provided

The current implamentation in the pages sets the backLink parameter to none however was still allowed to show the backlink in the render. Now it is fully omitted when None, instead of passing an empty string

I updated test logic to assert the .xyz-back-link element is present only when a backLink URL is defined and assert the element is omitted entirely when backLink is None