### PR TITLE
MMCA-5454: Remove the references to EO EORU UR on confirmation pages …

### DIFF
--- a/conf/messages.en
+++ b/conf/messages.en
@@ -43,7 +43,7 @@ feedback.after = will help us to improve it.
 # User Research
 # ----------------------------------------------------------
 user-research.subheader-text=Help us improve the service
-user-research.help.body-text=Do you have an EU EORI number? We''re carrying out user research to help improve our services.
+user-research.help.body-text=Your feedback is valuable to us.
 user-research.help.link=Sign up to take part in user research
 
 # Timeout Messages


### PR DESCRIPTION
…and make the guidance more general to encourage feedback